### PR TITLE
Fix position of Results panel on scrollY

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -51,6 +51,8 @@ input.ng-invalid {
 	position: fixed;
     top: 0;
     left: 50%;
+    width: 49%;
+
 }
 
 form {
@@ -80,6 +82,15 @@ form {
   background: #B7B5D6;
 }
 
+@media (max-width: 1200px) {
+	
+	.fixed {
+		width: 48.5%;
+	}
+	
+}
+
+
 @media (max-width: 768px) {
   .nav li {
 	font-size: 1.2em;
@@ -94,6 +105,7 @@ form {
 		position: relative;
 		left: auto;
 		top: auto;
+		width: auto;
 	}
 	
 	form {

--- a/css/main.css
+++ b/css/main.css
@@ -47,6 +47,12 @@ input.ng-invalid {
 	border-top: 1px solid #ddd;
 }
 
+.fixed {
+	position: fixed;
+    top: 0;
+    left: 50%;
+}
+
 form {
 	  border-color: #ddd;
 }
@@ -74,7 +80,7 @@ form {
   background: #B7B5D6;
 }
 
-@media (min-width: 768px) {
+@media (max-width: 768px) {
   .nav li {
 	font-size: 1.2em;
 }
@@ -83,6 +89,12 @@ form {
 	max-width: 500px;
 	margin: 1em auto;
 }
+	
+	.fixed {
+		position: relative;
+		left: auto;
+		top: auto;
+	}
 	
 	form {
 		margin: 1em auto;

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular.min.js"></script>
   <script type="text/javascript" src="scripts/app.js"></script>
+  <script type="text/javascript" src="scripts/directives.js"></script>
   <script type="text/javascript" src="scripts/services.js"></script>
   <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">
   <link href="css/main.css" rel="stylesheet">
@@ -47,7 +48,7 @@
             </form>
           </div><!-- end col -->
 
-          <div class="results col-sm-6">
+          <div ng-class="{fixed: scroll > 200}" scroll-position="scroll"  class="results col-sm-6">
             <h4>Score Breakdown</h4>
             <table class="table table-bordered table-striped">
               <thead>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -4,6 +4,9 @@ angular.module('calculator').controller('MainController', ['$http', 'totalsRules
   function($http, totalsRules, totalsHelpers) {
 
     var vm = this;
+    
+    // initialise scrollY tracking for results directive
+    vm.scroll = 0;
 
     vm.criteria = [];
     vm.totalScheme = [];

--- a/scripts/directives.js
+++ b/scripts/directives.js
@@ -1,0 +1,16 @@
+angular.module('calculator').directive('scrollPosition', function($window) {
+  return {
+    scope: {
+      scroll: '=scrollPosition'
+    },
+    link: function(scope, element, attrs) {
+            
+      var handler = function() {
+        scope.scroll = window.scrollY;
+      }
+      
+      window.addEventListener('scroll', scope.$apply.bind(scope, handler));
+      handler();
+    }
+  };
+});


### PR DESCRIPTION
- Add directives.js with directive to track window.scrollY position.
- Supporting CSS adds fixed positioning when scrolling past 200px
  on md screens and up.
